### PR TITLE
[WIP] Indexing along axes

### DIFF
--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -1,6 +1,6 @@
 module AxisArrays
 
-export AxisArray, Axis
+export AxisArray, Axis, Interval
 
 include("core.jl")
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -70,6 +70,9 @@ Base.getindex{T,N,D,names,Ax,S<:Int}(A::AxisArray{T,N,D,names,Ax}, idx::Abstract
 Base.eachindex(A::AxisArray) = eachindex(A.data)
 Base.getindex(A::AxisArray, idx::Base.IteratorsMD.CartesianIndex) = A.data[idx]
 
+# Cartesian iteration
+Base.eachindex(A::AxisArray) = eachindex(A.data)
+Base.getindex(A::AxisArray, idx::Base.IteratorsMD.CartesianIndex) = A.data[idx]
 # More complicated cases where we must create a subindexed AxisArray
 # TODO: do we want to be dogmatic about using views? For the data? For the axes?
 # TODO: perhaps it would be better to return an entirely lazy SubAxisArray view

--- a/src/core.jl
+++ b/src/core.jl
@@ -210,7 +210,7 @@ end
 # Categorical axes may be indexed by a vector of their elements
 function axisindexes{T}(::Type{Categorical}, ax::AbstractVector{T}, idx::AbstractVector{T}) 
     res = findin(ax, idx)
-    length(res) == 0 && error("index $idx not found")
+    length(res) == length(idx) || error("index $(setdiff(idx,ax)) not found")
     res
 end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -193,6 +193,12 @@ function axisindexes{T}(::Type{Categorical}, ax::AbstractVector{T}, idx::T)
     i == 0 && error("index $idx not found")
     i
 end
+# Categorical axes may be indexed by a vector of their elements
+function axisindexes{T}(::Type{Categorical}, ax::AbstractVector{T}, idx::AbstractVector{T}) 
+    res = findin(ax, idx)
+    length(res) == 0 && error("index $idx not found")
+    res
+end
 
 # TODO: why do I need the unused static parameters? (stack overflow otherwise)
 # TODO: this throws ambiguity warnings for idxs that are covered in Unions above

--- a/src/core.jl
+++ b/src/core.jl
@@ -55,6 +55,9 @@ let args = Expr[], idxs = Symbol[]
 end
 Base.getindex{T,N}(A::AxisArray{T,N}, idxs::Int...) = A.data[idxs...]
 
+# Cartesian iteration
+Base.eachindex(A::AxisArray) = eachindex(A.data)
+Base.getindex(A::AxisArray, idx::Base.IteratorsMD.CartesianIndex) = A.data[idx]
 # More complicated cases where we must create a subindexed AxisArray
 # TODO: do we want to be dogmatic about using views? For the data? For the axes?
 # TODO: perhaps it would be better to return an entirely lazy SubAxisArray view

--- a/src/core.jl
+++ b/src/core.jl
@@ -3,6 +3,15 @@
 immutable AxisArray{T,N,D<:AbstractArray,names,Ax} <: AbstractArray{T,N}
     data::D
     axes::Ax
+    function AxisArray(data, axes)
+        for i = 1:length(axes)
+            checkaxis(axes[i])
+            length(axes[i]) == size(data, i) || error("the length of each axis must match the corresponding size of data")
+        end
+        length(axes) <= ndims(data) || error("there may not be more axes than dimensions of data")
+        length(names) <= ndims(data) || error("there may not be more axis names than dimensions of data")
+        new{T,N,D,names,Ax}(data, axes)
+    end
 end
 # Allow AxisArrays that are missing dimensions and/or names?
 AxisArray{T,N}(A::AbstractArray{T,N}, axes::(AbstractVector...)=()) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,3 +37,20 @@ end
 # Linear indexing across multiple dimensions drops tracking of those dims
 @test A[:].axes == ()
 @test A[1:2,:].axes == (A.axes[1][1:2],)
+
+B = AxisArray(reshape(1:15, 5,3), (.1:.1:0.5, [:a, :b, :c]))
+
+# Test indexing by Intervals
+@test B[Interval(0.0,  0.5), :] == B[:,:]
+@test B[Interval(0.0,  0.3), :] == B[1:3,:]
+@test B[Interval(0.15, 0.3), :] == B[2:3,:]
+@test B[Interval(0.2,  0.5), :] == B[2:end,:]
+@test B[Interval(0.2,  0.6), :] == B[2:end,:]
+
+# Test Categorical indexing
+@test B[:, :a] == B[:,1]
+@test B[:, :c] == B[:,3]
+@test B[:, [:a]] == B[:,[1]]
+@test B[:, [:a,:c]] == B[:,[1,3]]
+
+@test B[Axis{:row}(Interval(0.15, 0.3))] == B[2:3,:]


### PR DESCRIPTION
This is less of a "work-in-progress" and more of a "something to start discussion" on indexing along axes. Here are feature ideas and other discussion items:

* It'd be nice if other packages can plug in axes types and define ways to index in to them.
* It'd be nice if other packages can declare that an axes type has order, so it can be indexed automatically (sounds like a good use of a Tim-Holy-Trait-Trick.
* It'd be nice to define default indexing for column names and for ranges on time axes. 
* For range indexes on time axes, should it be `A[[from, to],:]`, `A[(from,to),:]`, `A[1s:9s,:]`, or something else?
* What else should we provide by default for indexing?

What's implemented is an `axesindexes` method that tries to generalize indexing along an axes. It should return a UnitRange or other simple indexing type. It generates a bunch of warnings, and there are unchecked indexing cases. Here's what works, now:

```julia
julia> a = AxisArray(reshape([1:24], 12,2), (.1:.1:1.2, [:a,:b]))
12x2 AxisArrays.AxisArray{Int64,2,Array{Int64,2},(:row,:col),(FloatRange{Float64},Array{Symbol,1}),(Float64,Symbol)}:
  1  13
  2  14
  3  15
  4  16
  5  17
  6  18
  7  19
  8  20
  9  21
 10  22
 11  23
 12  24

julia> a[:,[:a]]
12x1 AxisArrays.AxisArray{Int64,2,SubArray{Int64,2,Array{Int64,2},(UnitRange{Int64},Array{Int64,1}),1},(:row,:col),(FloatRange{Float64},Array{Symbol,1}),(Float64,Symbol)}:
  1
  2
  3
  4
  5
  6
  7
  8
  9
 10
 11
 12

julia> a[[.9, 1.1],[:a]]
3x1 AxisArrays.AxisArray{Int64,2,SubArray{Int64,2,Array{Int64,2},(UnitRange{Int64},Array{Int64,1}),1},(:row,:col),(FloatRange{Float64},Array{Symbol,1}),(Float64,Symbol)}:
  9
 10
 11

julia> a[[.3, 1.1],:]
9x2 AxisArrays.AxisArray{Int64,2,SubArray{Int64,2,Array{Int64,2},(UnitRange{Int64},UnitRange{Int64}),1},(:row,:col),(FloatRange{Float64},Array{Symbol,1}),(Float64,Symbol)}:
  3  15
  4  16
  5  17
  6  18
  7  19
  8  20
  9  21
 10  22
 11  23

julia> a[[.9, Inf],:]
4x2 AxisArrays.AxisArray{Int64,2,SubArray{Int64,2,Array{Int64,2},(UnitRange{Int64},UnitRange{Int64}),1},(:row,:col),(FloatRange{Float64},Array{Symbol,1}),(Float64,Symbol)}:
  9  21
 10  22
 11  23
 12  24

julia> a = AxisArray(reshape([1:24], 12,2), (Ordered([.1:.1:1.2]), [:a,:b]))
12x2 AxisArrays.AxisArray{Int64,2,Array{Int64,2},(:row,:col),(AxisArrays.Ordered{Float64,Array{Float64,1}},Array{Symbol,1}),(Float64,Symbol)}:
  1  13
  2  14
  3  15
  4  16
  5  17
  6  18
  7  19
  8  20
  9  21
 10  22
 11  23
 12  24

julia> a[[.9, 1.1],:]
3x2 AxisArrays.AxisArray{Int64,2,SubArray{Int64,2,Array{Int64,2},(UnitRange{Int64},UnitRange{Int64}),1},(:row,:col),(AxisArrays.Ordered{Float64,Array{Float64,1}},Array{Symbol,1}),(Float64,Symbol)}:
  9  21
 10  22
 11  23

julia> a[[.9, 1.1],[:a]]
3x1 AxisArrays.AxisArray{Int64,2,SubArray{Int64,2,Array{Int64,2},(UnitRange{Int64},Array{Int64,1}),1},(:row,:col),(AxisArrays.Ordered{Float64,Array{Float64,1}},Array{Symbol,1}),(Float64,Symbol)}:
  9
 10
 11



```


