### PR TITLE
Add optional utilities for conversion to a DataFrame and for plotting with Gadfly

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,2 @@
+julia 0.4-
+Requires

--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -1,9 +1,12 @@
 module AxisArrays
 
+using Requires
+
 export AxisArray, Axis, Interval, axisnames
 
 include("core.jl")
 include("intervals.jl")
 include("indexing.jl")
+include("utils.jl")
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,67 @@
+@require DataFrames begin
+
+    """
+    Convert an AxisArray into a long-format DataFrame.
+    
+    ```julia
+    DataFrame(a::AxisArray)
+    ```
+    
+    ### Arguments
+    
+    * `a::AxisArray`
+    
+    ### Returns
+    
+    * `::DataFrame` : a DataFrame view into the AxisArray; columns are
+      added for each axis plus one column for the data (named `:data`).
+
+    """
+    function DataFrames.DataFrame(A::AxisArray)
+        colnames = Symbol[axisnames(A)..., :data]
+        sz = [1; size(A)...; 1]
+        columns = Any[DataFrames.RepeatedVector(a, prod(sz[1:i]), prod(sz[i+2:end])) for (i,a) in enumerate(axes(A))]
+        push!(columns, sub(A.data, 1:prod(sz)))
+        DataFrames.DataFrame(columns, colnames)
+    end
+
+end
+
+
+@require Gadfly begin
+
+    import DataArrays
+    ## Low-level code patching
+    function Gadfly.Scale.discretize_make_pda(values::DataFrames.RepeatedVector, levels=nothing)
+        if levels == nothing
+            return DataArrays.PooledDataArray(values)
+        else
+            return DataArrays.PooledDataArray(values[:], levels)
+        end
+    end
+
+    """
+    Plot an AxisArray using Gadfly.
+    
+    ```julia
+    Gadfly.plot(A::AxisArray, args...; kargs...)
+    ```
+    
+    ### Arguments
+    
+    * `A::AxisArray`
+
+    All other arguments are passed to Gadfly.plot.
+    
+    ### Examples
+    
+    ```julia
+    using Gadfly
+    A = AxisArray(reshape([1:24], 12,2), (.1:.1:1.2, [:a,:b]))
+    plot(A, x = :row, y = :data, color = :col)
+    ```
+
+    """
+    Gadfly.plot(A::AxisArray, args...; kwargs...) = Gadfly.plot(DataFrames.DataFrame(A), args...; kwargs...)
+    
+end


### PR DESCRIPTION
This adds a dependency on Requires.jl. It's a small package that has worked well for me. The main advantage of this code is that it gives us a quick way to plot AxisArrays using Gadfly.

Note that this also requires the development version of DataFrames (I added a feature needed for this).

Note that this causes a ton of warnings when DataFrames and Gadfly are loaded. Most are due to other packages, but some are ambiguity warnings between DataArrays and AxisArrays. DataArrays will probably undergo a lot of change as they convert to some sort of Nullables representation, so I wouldn't worry about these for now. Ambiguity warnings are a PITA. Hopefully, Jeff's type work will fix all that. 