### PR TITLE
adding TimeArray nested module for experimentation

### DIFF
--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -8,5 +8,6 @@ include("core.jl")
 include("intervals.jl")
 include("indexing.jl")
 include("utils.jl")
+include("time/timeseries.jl")
 
 end

--- a/src/time/timeseries.jl
+++ b/src/time/timeseries.jl
@@ -1,0 +1,12 @@
+using AxisArrays, MarketData
+
+module TimeArray
+
+using AxisArrays, MarketData
+
+export Apple, Boeing 
+
+const Apple  = AxisArray(AAPL.values, (AAPL.timestamp, AAPL.colnames))
+const Boeing = AxisArray(BA.values, (BA.timestamp, BA.colnames))
+ 
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+FactCheck

--- a/test/timeseries.jl
+++ b/test/timeseries.jl
@@ -1,0 +1,19 @@
+using AxisArrays.TimeArray, MarketData
+
+facts("Apple and Boeing AxisArrays") do
+
+    context("Apple and Boeing have correct axes values") do
+        @fact Apple.axes[1][1]  => Date(1980,12,12) 
+        @fact Apple.axes[2][1]  => "Open"
+        @fact Boeing.axes[1][1] => Date(1962,1,2) 
+        @fact Boeing.axes[2][1] => "Open"
+    end 
+    context("Apple and Boeing have correct data values") do
+        @fact Apple.data[1][1]  => 28.75
+        @fact size(Apple,1)     => 8336
+        @fact size(Apple,2)     => 12
+        @fact Boeing.data[1][1] => 50.88
+        @fact size(Boeing,1)    => 13090
+        @fact size(Boeing,2)    => 12
+    end
+end


### PR DESCRIPTION
This works as advertised but for the fact that it loads extra packages (TimeSeries,MarketData) without asking first, which slows things down. 

I think there is a workaround to this that @rened has used in the past.

Here is a quick demo

````julia
julia> using AxisArrays # takes really long now because of MarketData, which depends on HDF5, JLD

julia> Apple
ERROR: UndefVarError: Apple not defined

julia> using AxisArrays.TimeArray

julia> Apple
8336x12 AxisArrays.AxisArray{Float64,2,Array{Float64,2},(:row,:col),(Array{Base.Dates.Date,1},Array{UTF8String,1})}:
  28.75   28.88   28.75   28.75       2.0939e6   0.0  1.0    3.37658    3.39185    3.37658    3.37658  1.67512e7
  27.38   27.38   27.25   27.25  785200.0        0.0  1.0    3.21568    3.21568    3.20041    3.20041  6.2816e6 
  25.38   25.38   25.25   25.25  472000.0        0.0  1.0    2.98079    2.98079    2.96552    2.96552  3.776e6  
  25.88   26.0    25.88   25.88  385900.0        0.0  1.0    3.03951    3.05361    3.03951    3.03951  3.0872e6 
  26.62   26.75   26.62   26.62  327900.0        0.0  1.0    3.12642    3.14169    3.12642    3.12642  2.6232e6 
  28.25   28.38   28.25   28.25  217100.0        0.0  1.0    3.31786    3.33313    3.31786    3.31786  1.7368e6 
  29.62   29.75   29.62   29.62  166800.0        0.0  1.0    3.47876    3.49403    3.47876    3.47876  1.3344e6 
   ⋮                                             ⋮                                            ⋮                 
 545.43  551.61  544.82  549.02       1.55862e7  0.0  1.0  542.203    548.347    541.597    545.772    1.55862e7
 568.0   570.72  562.76  570.09       1.79038e7  0.0  1.0  564.64     567.344    559.431    566.717    1.79038e7
 569.89  571.88  566.03  567.67       5.9841e6   0.0  1.0  566.519    568.497    562.681    564.312    5.9841e6 
 568.1   569.5   563.38  563.9        7.286e6    0.0  1.0  564.739    566.131    560.047    560.564    7.286e6  
 563.82  564.41  559.5   560.09       8.0673e6   0.0  1.0  560.484    561.071    556.19     556.777    8.0673e6 
 557.46  560.09  552.32  554.52       9.0582e6   0.0  1.0  554.162    556.777    549.053    551.24     9.0582e6 
 554.17  561.28  554.0   561.02       7.9673e6   0.0  1.0  550.892    557.96     550.723    557.701    7.9673e6 
````