### PR TITLE
Add a SortedVector for keyed axis indexes and hierarchical indexing

### DIFF
--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -7,6 +7,7 @@ export AxisArray, Axis, Interval, axisnames, axisvalues, axisdim, axes
 include("core.jl")
 include("intervals.jl")
 include("indexing.jl")
+include("sortedvector.jl")
 include("utils.jl")
 
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -291,7 +291,7 @@ checkaxis(ax) = checkaxis(axistrait(ax), ax)
 checkaxis(::Type{Unsupported}, ax) = nothing # TODO: warn or error?
 # Dimensional axes must be monotonically increasing
 checkaxis{T}(::Type{Dimensional}, ax::Range{T}) = step(ax) > zero(T) || error("Dimensional axes must be monotonically increasing")
-checkaxis(::Type{Dimensional}, ax) = issorted(ax, lt=(<=)) || error("Dimensional axes must be monotonically increasing")
+checkaxis(::Type{Dimensional}, ax) = issorted(ax) || error("Dimensional axes must be monotonically increasing")
 # Categorical axes must simply be unique
 function checkaxis(::Type{Categorical}, ax)
     seen = Set{eltype(ax)}()

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -78,6 +78,8 @@ axisindexes(ax, idx) = axisindexes(axistrait(ax.val), ax.val, idx)
 axisindexes(::Type{Unsupported}, ax, idx) = error("elementwise indexing is not supported for axes of type $(typeof(ax))")
 # Dimensional axes may be indexed by intervals of their elements
 axisindexes{T}(::Type{Dimensional}, ax::AbstractVector{T}, idx::Interval{T}) = searchsorted(ax, idx)
+# Dimensional axes may also be indexed directy by their elements
+axisindexes{T}(::Type{Dimensional}, ax::AbstractVector{T}, idx::T) = searchsorted(ax, Interval(idx,idx))
 # Categorical axes may be indexed by their elements
 function axisindexes{T}(::Type{Categorical}, ax::AbstractVector{T}, idx::T)
     i = findfirst(ax, idx)

--- a/src/sortedvector.jl
+++ b/src/sortedvector.jl
@@ -1,0 +1,100 @@
+
+export SortedVector
+
+@doc """
+
+A SortedVector is an AbstractVector where the underlying data is
+ordered (monotonically increasing).
+
+Indexing that would unsort the data is prohibited. A SortedVector is a
+Dimensional axis, and no checking is done to ensure that the data is
+sorted. Duplicate values are allowed.
+
+A SortedVector axis can be indexed with an Interval, with a value, or
+with a vector of values. Use of a SortedVector{Tuple} axis allows
+indexing similar to the hierarchical index of the Python Pandas
+package or the R data.table package.
+
+### Constructors
+
+```julia
+SortedVector(x::AbstractVector)
+```
+
+### Keyword Arguments
+
+* `x::AbstractVector` : the wrapped vector
+
+### Examples
+
+```julia
+v = SortedVector(collect([1.; 10.; 10:15.]))
+A = AxisArray(reshape(1:16, 8, 2), v, [:a, :b])
+A[Interval(8.,12.), :]
+A[1., :]
+A[10., :]
+
+## Hierarchical index example with three key levels
+
+data = reshape(1.:40., 20, 2)
+v = collect(zip([:a, :b, :c][rand(1:3,20)], [:x,:y][rand(1:2,20)], [:x,:y][rand(1:2,20)]))
+idx = sortperm(v)
+A = AxisArray(data[idx,:], SortedVector(v[idx]), [:a, :b])
+A[:b, :]
+A[[:a,:c], :]
+A[(:a,:x), :]
+A[(:a,:x,:x), :]
+A[Interval(:a,:b), :]
+A[Interval((:a,:x),(:b,:x)), :]
+```
+
+""" ->
+immutable SortedVector{T} <: AbstractVector{T}
+    data::AbstractVector{T}
+end
+
+Base.getindex(v::SortedVector, idx::Int) = v.data[idx]
+Base.getindex(v::SortedVector, idx::Range1) = SortedVector(v.data[idx])
+Base.getindex(v::SortedVector, idx::StepRange) =
+    step(idx) > 0 ? SortedVector(v.data[idx]) : error("step must be positive to index a SortedVector")
+Base.getindex(v::SortedVector, idx::AbstractVector) =
+    issorted(idx) ? SortedVector(v.data[idx]) : error("index must be monotonically increasing to index a SortedVector")
+
+Base.length(v::SortedVector) = length(v.data)
+Base.size(v::SortedVector) = size(v.data)
+Base.size(v::SortedVector, i) = size(v.data, i)
+
+axistrait(::SortedVector) = Dimensional
+checkaxis(::SortedVector) = nothing
+
+
+## Add some special indexing for SortedVector{Tuple}'s to achieve something like
+## Panda's hierarchical indexing
+
+axisindexes{T<:Tuple,S}(ax::Axis{S,SortedVector{T}}, idx) =
+    searchsorted(ax.val, idx, 1, length(ax.val), Base.ord(_isless,identity,false,Base.Forward))
+
+axisindexes{T<:Tuple,S}(ax::Axis{S,SortedVector{T}}, idx::AbstractArray) =
+    vcat([axisindexes(ax, i) for i in idx]...)
+
+
+## Use a modification of `isless`, so that (:a,) is not less than (:a, :b).
+## This allows for more natural indexing.
+
+_isless(x,y) = isless(x,y)
+
+function _isless(t1::Tuple, t2::Tuple)
+    n1, n2 = length(t1), length(t2)
+    for i = 1:min(n1, n2)
+        a, b = t1[i], t2[i]
+        if !isequal(a, b)
+            return _isless(a, b)
+        end
+    end
+    return false
+end
+_isless{T<:Tuple}(t1::Interval{T}, t2::Tuple) = _isless(t1, Interval(t2,t2))
+_isless{T<:Tuple}(t1::Tuple, t2::Interval{T}) = _isless(Interval(t1,t1), t2)
+_isless(t1::Tuple, t2) = _isless(t1,(t2,))
+_isless(t1, t2::Tuple) = _isless((t1,),t2)
+_isless(a::Interval, b::Interval) = _isless(a.hi, b.lo)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using Base.Test
 
 include("core.jl")
 include("indexing.jl")
+include("sortedvector.jl")

--- a/test/sortedvector.jl
+++ b/test/sortedvector.jl
@@ -1,0 +1,21 @@
+
+# Test SortedVector
+v = SortedVector(collect([1.; 10.; 10:15.]))
+A = AxisArray(reshape(1:16, 8, 2), v, [:a, :b])
+@test A[Interval(8.,12.), :] == A[2:5, :]
+@test A[1., :] == A[1, :]
+@test A[10., :] == A[2:3, :]
+
+# Test SortedVector with a hierarchical index (indexed using Tuples)
+srand(1234)
+data = reshape(1.:40., 20, 2)
+v = collect(zip([:a, :b, :c][rand(1:3,20)], [:x,:y][rand(1:2,20)], [:x,:y][rand(1:2,20)]))
+idx = sortperm(v)
+A = AxisArray(data[idx,:], SortedVector(v[idx]), [:a, :b])
+@test A[:b, :] == A[5:12, :]
+@test A[[:a,:c], :] == A[[1:4;13:end], :]
+@test A[(:a,:y), :] == A[2:4, :]
+@test A[(:c,:y,:y), :] == A[16:end, :]
+@test A[Interval(:a,:b), :] == A[1:12, :]
+@test A[Interval((:a,:x),(:b,:x)), :] ==  A[1:9, :]
+@test A[[Interval((:a,:x),(:b,:x)),:c], :] ==  A[[1:9;13:end], :]


### PR DESCRIPTION
Add a SortedVector type that assumes sorting. Also, change the Dimensional trait to allow duplicates and add indexing by value. A SortedVector{Tuple} allows hierarchical indexing similar to [pandas](http://pandas.pydata.org/) or [data.table](https://github.com/Rdatatable/data.table/wiki). SortedVector hits one of the roadmap (issue #7) bullets.

This also changes axis indexing in two ways:

* Duplicates are allowed. This also helps with Sims.jl because the timescale can have repeated values before and after events. 

* Dimensional axes can now be indexed by value. If there are duplicates, all indexes that match are returned. 

Here are examples of SortedVector and hierarchical indexing:

```julia
v = SortedVector(collect([1., 10., 10:15.]))
A = AxisArray(reshape(1:16, 8, 2), v, [:a, :b])
A[Interval(8.,12.), :]
A[1., :]
A[10., :]

## Hierarchical index example with three key levels

data = reshape(1.:40., 20, 2)
v = collect(zip([:a, :b, :c][rand(1:3,20)], [:x,:y][rand(1:2,20)], [:x,:y][rand(1:2,20)]))
idx = sortperm(v)
A = AxisArray(data[idx,:], SortedVector(v[idx]), [:a, :b])
A[:b, :]
A[[:a,:c], :]
A[(:a,:x), :]
A[(:a,:x,:x), :]
A[Interval(:a,:b), :]
A[Interval((:a,:x),(:b,:x)), :]
```

Using an Array of Tuples might not be the most efficient storage format for this, but it will allow us to play around with this feature. For analysis of time series data in R, I use both zoo (it's like AxisArrays) and data.tables. The zoo package provides nice plotting, so I tend to use that for more structured data, and I use data.tables when I need more flexibility. My motivation for this PR is to have one package/data structure that can be used for both approaches.
