### PR TITLE
Removed old range ordering check and fixed deprecation warnings

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -44,7 +44,7 @@ end
 # Constructed exclusively through Axis{:symbol}(...) or Axis{1}(...)
 Base.call{name,T}(::Type{Axis{name}}, I::T=()) = Axis{name,T}(I)
 Base.(:(==)){name,T}(A::Axis{name,T}, B::Axis{name,T}) = A.val == B.val
-Base.hash{name}(A::Axis{name}, hx::Uint) = hash(A.val, hash(name, hx))
+Base.hash{name}(A::Axis{name}, hx::UInt) = hash(A.val, hash(name, hx))
 axistype{name,T}(::Axis{name,T}) = T
 axistype{name,T}(::Type{Axis{name,T}}) = T
 # Pass indexing and related functions straight through to the wrapped value
@@ -310,13 +310,12 @@ immutable Categorical <: AxisTrait end
 immutable Unsupported <: AxisTrait end
 
 axistrait(::Any) = Unsupported
-axistrait{T<:Union(Number, Dates.AbstractTime)}(::AbstractVector{T}) = Dimensional
-axistrait{T<:Union(Symbol, AbstractString)}(::AbstractVector{T}) = Categorical
+axistrait{T<:Union{Number, Dates.AbstractTime}}(::AbstractVector{T}) = Dimensional
+axistrait{T<:Union{Symbol, AbstractString}}(::AbstractVector{T}) = Categorical
 
 checkaxis(ax) = checkaxis(axistrait(ax), ax)
 checkaxis(::Type{Unsupported}, ax) = nothing # TODO: warn or error?
 # Dimensional axes must be monotonically increasing
-checkaxis{T}(::Type{Dimensional}, ax::Range{T}) = step(ax) > zero(T) || throw(ArgumentError("Dimensional axes must be monotonically increasing"))
 checkaxis(::Type{Dimensional}, ax) = issorted(ax) || throw(ArgumentError("Dimensional axes must be monotonically increasing"))
 # Categorical axes must simply be unique
 function checkaxis(::Type{Categorical}, ax)

--- a/test/core.jl
+++ b/test/core.jl
@@ -110,5 +110,11 @@ A = AxisArray(reshape(1:24, 2,3,4),
 @test AxisArrays.axistype(Axis{1}(1:2)) == typeof(1:2)
 @test axisnames(Axis{1}, Axis{2}, Axis{3}) == (1,2,3)
 
+# Test Timetype axis construction
+dt, vals = DateTime(2010, 1, 2, 3, 40), randn(5,2)
+A = AxisArray(vals, Axis{:Timestamp}(dt-Dates.Hour(2):Dates.Hour(1):dt+Dates.Hour(2)), Axis{:Cols}([:A, :B]))
+@test A[:, :A].data == vals[:, 1]
+@test A[dt, :].data == vals[3, :]
+
 # Simply run the display method to ensure no stupid errors
 writemime(IOBuffer(),MIME("text/plain"),A)


### PR DESCRIPTION
As discussed in https://github.com/mbauman/AxisArrays.jl/issues/22 - allows for `TimeType` dimensional axes.

```julia
julia> using AxisArrays, Base.Dates

julia> A = AxisArray(randn(5,2), Axis{:Timestamp}(now()-Hour(2):Hour(1):now()+Hour(2)), Axis{:Cols}([:A, :B]))
2-dimensional AxisArray{Float64,2,...} with axes:
    :Timestamp, 2016-04-25T16:37:22:1 hour:2016-04-25T20:37:22
    :Cols, [:A,:B]
And data, a 5x2 Array{Float64,2}:
 -0.150798   -0.174845
 -0.943928    0.718984
  0.0884346   1.13286 
 -1.23035    -0.831126
 -1.36034     0.402844
```