### PR TITLE
Fixes and depwarns for julia 0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4-
+julia 0.4
 Requires
 Iterators
-
+Compat

--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -1,6 +1,6 @@
 module AxisArrays
 
-using Requires, Tuples, RangeArrays, Iterators
+using Requires, Tuples, RangeArrays, Iterators, Compat
 
 export AxisArray, Axis, Interval, axisnames, axisvalues, axisdim, axes, .., atindex
 

--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -1,6 +1,7 @@
 module AxisArrays
 
 using Requires, Tuples, RangeArrays, Iterators, Compat
+using Compat.view
 
 export AxisArray, Axis, Interval, axisnames, axisvalues, axisdim, axes, .., atindex
 

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -13,7 +13,7 @@ sizes{T<:AxisArray}(As::T...) = tuple(zip(map(size, As)...)...)
 matchingdims{N,T<:AxisArray}(As::NTuple{N,T}) = all(equalvalued, sizes(As...))
 matchingdimsexcept{N,T<:AxisArray}(As::NTuple{N,T}, n::Int) = all(equalvalued, sizes(As[[1:n-1; n+1:end]]...))
 
-function Base.cat{T<:AxisArray}(n::Int, As::T...)
+function Base.cat{T<:AxisArray}(n::Integer, As::T...)
     if n <= ndims(As[1])
         matchingdimsexcept(As, n) || error("All non-concatenated axes must be identically-valued")
         newaxis = Axis{axisnames(As[1])[n]}(vcat(map(A -> A.axes[n].val, As)...))

--- a/src/core.jl
+++ b/src/core.jl
@@ -20,13 +20,13 @@ Axis{name}(I)
 
 ### Arguments
 
-* `name` : the axis name symbol or integer dimension
+* `name` : the axis name Symbol or integer dimension
 * `I` : the indexer, any indexing type that the axis supports
 
 ### Examples
 
 Here is an example with a Dimensional axis representing a time
-sequence along rows and a Categorical axis of symbols for column
+sequence along rows and a Categorical axis of Symbols for column
 headers.
 
 ```julia
@@ -42,8 +42,8 @@ immutable Axis{name,T}
     val::T
 end
 # Constructed exclusively through Axis{:symbol}(...) or Axis{1}(...)
-Base.call{name,T}(::Type{Axis{name}}, I::T=()) = Axis{name,T}(I)
-Base.(:(==)){name,T}(A::Axis{name,T}, B::Axis{name,T}) = A.val == B.val
+@compat (::Type{Axis{name}}){name,T}(I::T=()) = Axis{name,T}(I)
+@compat Base.:(==){name,T}(A::Axis{name,T}, B::Axis{name,T}) = A.val == B.val
 Base.hash{name}(A::Axis{name}, hx::UInt) = hash(A.val, hash(name, hx))
 axistype{name,T}(::Axis{name,T}) = T
 axistype{name,T}(::Type{Axis{name,T}}) = T
@@ -103,7 +103,7 @@ custom indexing type for that particular type of axis.
 
 Two main types of axes supported by default include:
 
-* Categorical axis -- These are vectors of labels, normally symbols or
+* Categorical axis -- These are vectors of labels, normally Symbols or
   strings. Elements or slices can be indexed by elements or vectors
   of elements.
 
@@ -128,7 +128,7 @@ For more advanced indexing, you can define custom methods for
 
 Here is an example with a Dimensional axis representing a time
 sequence along rows (it's a FloatRange) and a Categorical axis of
-symbols for column headers.
+Symbols for column headers.
 
 ```julia
 A = AxisArray(reshape(1:15, 5, 3), Axis{:time}(.1:.1:0.5), Axis{:col}([:a, :b, :c]))
@@ -144,13 +144,13 @@ immutable AxisArray{T,N,D,Ax} <: AbstractArray{T,N}
     AxisArray(data::AbstractArray, axs) = new{T,N,D,Ax}(data, axs)
 end
 #
-_defaultdimname(i) = i == 1 ? (:row) : i == 2 ? (:col) : i == 3 ? (:page) : symbol(:dim_, i)
+_defaultdimname(i) = i == 1 ? (:row) : i == 2 ? (:col) : i == 3 ? (:page) : Symbol(:dim_, i)
 AxisArray(A::AbstractArray, axs::Axis...) = AxisArray(A, axs)
 @generated function AxisArray{T,N,L}(A::AbstractArray{T,N}, axs::NTuple{L,Axis})
     ax = Expr(:tuple)
     Ax = Tuples.concatenate(axs, NTuple(i->Axis{_defaultdimname(i+L),UnitRange{Int64}},N-L))
     if !isa(axisnames(Tuples.collect(axs)...), Tuple{Vararg{Symbol}})
-        return :(throw(ArgumentError("the Axis names must be symbols")))
+        return :(throw(ArgumentError("the Axis names must be Symbols")))
     end
     for i=1:L
         push!(ax.args, :(axs[$i]))
@@ -256,7 +256,7 @@ end
         println(io)
     end
     print(io, "And data, a ")
-    writemime(io, m, A.data)
+    show(io, m, A.data)
 end
 
 # Custom methods specific to AxisArrays
@@ -266,7 +266,7 @@ end
     axisnames(ax::Axis...)            -> (Symbol...)
     axisnames(::Type{Axis{...}}...)   -> (Symbol...)
 
-Returns the axis names of an AxisArray or list of Axises as a tuple of symbols.
+Returns the axis names of an AxisArray or list of Axises as a tuple of Symbols.
 """ ->
 axisnames{T,N,D,Ax}(::AxisArray{T,N,D,Ax})       = axisnames(Tuples.collect(Ax)...)
 axisnames{T,N,D,Ax}(::Type{AxisArray{T,N,D,Ax}}) = axisnames(Tuples.collect(Ax)...)

--- a/src/core.jl
+++ b/src/core.jl
@@ -248,11 +248,11 @@ end
 # A simple display method to include axis information. It might be nice to
 # eventually display the axis labels alongside the data array, but that is
 # much more difficult.
-function Base.writemime{T,N}(io::IO, m::MIME"text/plain", A::AxisArray{T,N})
+@compat function Base.show{T,N}(io::IO, m::MIME"text/plain", A::AxisArray{T,N})
     println(io, "$N-dimensional AxisArray{$T,$N,...} with axes:")
     for (name, val) in zip(axisnames(A), axisvalues(A))
         print(io, "    :$name, ")
-        Base.showlimited(io, val)
+        show(IOContext(io, :limit=>true), val)
         println(io)
     end
     print(io, "And data, a ")

--- a/src/core.jl
+++ b/src/core.jl
@@ -210,19 +210,19 @@ Base.convert{T,N}(::Type{Array{T,N}}, A::AxisArray{T,N}) = convert(Array{T,N}, A
 # AxisArray. But if we're changing dimensions, there's no way it can know how
 # to keep track of the axes, so just punt and return a regular old Array.
 # TODO: would it feel more consistent to return an AxisArray without any axes?
-Base.similar{T}(A::AxisArray{T})          = (d = similar(A.data, T); AxisArray(d, A.axes))
-Base.similar{T}(A::AxisArray{T}, S)       = (d = similar(A.data, S); AxisArray(d, A.axes))
-Base.similar{T}(A::AxisArray{T}, S, ::Tuple{}) = (d = similar(A.data, S); AxisArray(d, A.axes))
+Base.similar{T}(A::AxisArray{T})                = (d = similar(A.data, T); AxisArray(d, A.axes))
+Base.similar{T}(A::AxisArray{T}, S::Type)       = (d = similar(A.data, S); AxisArray(d, A.axes))
+Base.similar{T}(A::AxisArray{T}, S::Type, ::Tuple{}) = (d = similar(A.data, S); AxisArray(d, A.axes))
 Base.similar{T}(A::AxisArray{T}, dims::Int)         = similar(A, T, (dims,))
 Base.similar{T}(A::AxisArray{T}, dims::Int...)      = similar(A, T, dims)
-Base.similar{T}(A::AxisArray{T}, dims::Tuple{Vararg{Int}})    = similar(A, T, dims)
-Base.similar{T}(A::AxisArray{T}, S, dims::Int...)   = similar(A.data, S, dims)
-Base.similar{T}(A::AxisArray{T}, S, dims::Tuple{Vararg{Int}}) = similar(A.data, S, dims)
+Base.similar{T}(A::AxisArray{T}, dims::Tuple{Vararg{Int}}) = similar(A, T, dims)
+Base.similar{T}(A::AxisArray{T}, S::Type, dims::Int...)    = similar(A.data, S, dims)
+Base.similar{T}(A::AxisArray{T}, S::Type, dims::Tuple{Vararg{Int}}) = similar(A.data, S, dims)
 # If, however, we pass Axis objects containing the new axis for that dimension,
 # we can return a similar AxisArray with an appropriately modified size
 Base.similar{T}(A::AxisArray{T}, axs::Axis...) = similar(A, T, axs)
-Base.similar{T}(A::AxisArray{T}, S, axs::Axis...) = similar(A, S, axs)
-@generated function Base.similar{T,N}(A::AxisArray{T,N}, S, axs::Tuple{Vararg{Axis}})
+Base.similar{T}(A::AxisArray{T}, S::Type, axs::Axis...) = similar(A, S, axs)
+@generated function Base.similar{T,N}(A::AxisArray{T,N}, S::Type, axs::Tuple{Vararg{Axis}})
     sz = Expr(:tuple)
     ax = Expr(:tuple)
     for d=1:N

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -60,8 +60,10 @@ end
 # When we index with non-vector arrays, we *add* dimensions. This isn't
 # supported by SubArray currently, so we instead return a copy.
 # TODO: we probably shouldn't hack Base like this, but it's so convenient...
-@inline Base.index_shape_dim(A, dim, i::AbstractArray{Bool}, I...) = (sum(i), Base.index_shape_dim(A, dim+1, I...)...)
-@inline Base.index_shape_dim(A, dim, i::AbstractArray, I...) = (size(i)..., Base.index_shape_dim(A, dim+1, I...)...)
+if VERSION < v"0.5.0-dev"
+    @inline Base.index_shape_dim(A, dim, i::AbstractArray{Bool}, I...) = (sum(i), Base.index_shape_dim(A, dim+1, I...)...)
+    @inline Base.index_shape_dim(A, dim, i::AbstractArray, I...) = (size(i)..., Base.index_shape_dim(A, dim+1, I...)...)
+end
 @generated function Base.getindex(A::AxisArray, I::Union{Idx, AbstractArray{Int}}...)
     N = length(I)
     Isplat = [:(I[$d]) for d=1:N]

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -37,22 +37,13 @@ Base.setindex!(A::AxisArray, v, idx::Base.IteratorsMD.CartesianIndex) = (A.data[
     reshape = false
     newshape = Expr[]
     for i = 1:newdims-droplastaxis
-        if idxs[i] <: AxisArray
-            idxnames = axisnames(idxs[i])
-            push!(axes.args, :($(Axis{symbol(names[i], "_", idxnames[1])})(idxs[$i].axes[1].val)))
-        elseif idxs[i] <: Real
-            idx = :(idxs[$i]:idxs[$i])
-            push!(axes.args, :($(Axis{names[i]})(A.axes[$i].val[$idx])))
-            push!(Isplat, :(idxs[$i]))
-        else
-            idx = :(idxs[$i])
-            push!(axes.args, :($(Axis{names[i]})(A.axes[$i].val[$idx])))
-            push!(Isplat, :(idxs[$i]))
-        end
+        prepaxis!(axes.args, Isplat, idxs[i], names, i)
     end
-    Isplat = Expr[:(idxs[$d]) for d=1:length(idxs)]
+    for i = newdims-droplastaxis+1:length(idxs)
+        push!(Isplat, :(idxs[$i]))
+    end
     quote
-        data = sub(A.data, $(Isplat...))
+        data = view(A.data, $(Isplat...))
         AxisArray(data, $axes) # TODO: avoid checking the axes here
     end
 end
@@ -81,13 +72,13 @@ end
         if I[d] <: AxisArray
             idxnames = axisnames(I[d])
             for i=1:ndims(I[d])
-                push!(newaxes, :($(Axis{symbol(names[d], "_", idxnames[i])})(I[$d].axes[$i].val)))
+                push!(newaxes, :($(Axis{Symbol(names[d], "_", idxnames[i])})(I[$d].axes[$i].val)))
             end
         elseif I[d] <: Idx
             push!(newaxes, :($(Axis{names[d]})(A.axes[$d].val[J[$d]])))
         elseif I[d] <: AbstractArray
             for i=1:ndims(I[d])
-                push!(newaxes, :($(Axis{symbol(names[d], "_", i)})(1:size(I[$d], $i))))
+                push!(newaxes, :($(Axis{Symbol(names[d], "_", i)})(1:size(I[$d], $i))))
             end
         end
     end
@@ -101,7 +92,7 @@ end
         dest = similar(A.data, sz)
         D = eachindex(dest)
         Ds = start(D)
-        Base.Cartesian.@nloops $N i d->(1:idx_lens[d]) d->(j_d = unsafe_getindex(J[d], i_d)) begin
+        Base.Cartesian.@nloops $N i d->(1:idx_lens[d]) d->(@inbounds j_d = J[d][i_d]) begin
             d, Ds = next(D, Ds)
             v = Base.Cartesian.@ncall $N unsafe_getindex src j
             unsafe_setindex!(dest, v, d)
@@ -218,4 +209,31 @@ end
     end
     meta = Expr(:meta, :inline)
     return :($meta; $ex)
+end
+
+function prepaxis!{I<:Union{AbstractVector,Colon}}(axesargs, Isplat, ::Type{I}, names, i)
+    idx = :(idxs[$i])
+    push!(axesargs, :($(Axis{names[i]})(A.axes[$i].val[$idx])))
+    push!(Isplat, :(idxs[$i]))
+    axesargs, Isplat
+end
+function prepaxis!{I<:AxisArray}(axesargs, Isplat, ::Type{I}, names, i)
+    idxnames = axisnames(I)
+    push!(axesargs, :($(Axis{Symbol(names[i], "_", idxnames[1])})(idxs[$i].axes[1].val)))
+    push!(Isplat, :(idxs[$i]))
+    axesargs, Isplat
+end
+# For anything scalar-like
+if VERSION < v"0.5.0-dev"
+    function prepaxis!{I}(axesargs, Isplat, ::Type{I}, names, i)
+        idx = :(idxs[$i]:idxs[$i])
+        push!(axesargs, :($(Axis{names[i]})(A.axes[$i].val[$idx])))
+        push!(Isplat, idx)
+        axesargs, Isplat
+    end
+else
+    function prepaxis!{I}(axesargs, Isplat, ::Type{I}, names, i)
+        push!(Isplat, :(idxs[$i]))
+        axesargs, Isplat
+    end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -116,4 +116,4 @@ A = AxisArray(vals, Axis{:Timestamp}(dt-Dates.Hour(2):Dates.Hour(1):dt+Dates.Hou
 @test A[dt, :].data == vals[3, :]
 
 # Simply run the display method to ensure no stupid errors
-writemime(IOBuffer(),MIME("text/plain"),A)
+@compat show(IOBuffer(),MIME("text/plain"),A)

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -61,7 +61,7 @@ A = AxisArray(reshape(1:256, 4,4,4,4), Axis{:d1}(.1:.1:.4), Axis{:d2}(1//10:1//1
 @test A.data[:,:,:,1:2] == A[Axis{:d4}([:a,:b])]               == A[:,:,:,[:a,:b]]               == A[:,:,:,[:a,:b],1]
 
 A = AxisArray(reshape(1:32, 2, 2, 2, 2, 2), .1:.1:.2, .1:.1:.2, .1:.1:.2, [:a, :b], [:c, :d])
-@test A[Interval(.15, .25), Interval(.05, .15), Interval(.15, .25), :a] == A.data[2, 1, 2, 1, :]
+@test A[Interval(.15, .25), Interval(.05, .15), Interval(.15, .25), :a] == A.data[2:2, 1:1, 2:2, 1, :]
 @test A[Axis{:dim_5}(2)] == A.data[:, :, :, :, 2]
 
 # Test vectors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using AxisArrays
-using Base.Test
+using Base.Test, Compat
 
 include("core.jl")
 include("intervals.jl")


### PR DESCRIPTION
This fixes several problems on julia 0.5, including an error thrown by `using AxisArrays`, and eliminates most (but deliberately not all) deprecation warnings.

Left to do: some tests still fail. While I haven't dug deeply, I'm guessing it's a consequence of this package [using `sub` semantics](https://github.com/mbauman/AxisArrays.jl/blob/7674f5d74d0f79271783ca10695559a61b9b0b14/src/indexing.jl#L43-L46) whereas julia master has moved on to `slice` semantics. (This is why I left the sub/slice/view depwarns present, as a TODO reminder.) I recommend that this package follow suit and adopt `slice` (now called `view`) semantics.

This would be a breaking change, so I didn't want to start on it without checking first.