### PR TITLE
Simplify slicing with a particular axis. Closes #33

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -62,6 +62,7 @@ Base.unsafe_getindex(A::Axis, i...) = Base.unsafe_getindex(A, i...)
 Base.eltype{_,T}(::Type{Axis{_,T}}) = eltype(T)
 Base.size(A::Axis) = size(A.val)
 Base.length(A::Axis) = length(A.val)
+@compat (A::Axis{name}){name}(i) = Axis{name}(i)
 
 @doc """
 An AxisArray is an AbstractArray that wraps another AbstractArray and

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -55,6 +55,8 @@ B = AxisArray(reshape(1:15, 5,3), .1:.1:0.5, [:a, :b, :c])
 @test B[Axis{:row}(Interval(0.15, 0.3))] == B[2:3,:]
 
 A = AxisArray(reshape(1:256, 4,4,4,4), Axis{:d1}(.1:.1:.4), Axis{:d2}(1//10:1//10:4//10), Axis{:d3}(["1","2","3","4"]), Axis{:d4}([:a, :b, :c, :d]))
+ax1 = axes(A)[1]
+@test A[Axis{:d1}(2)] == A[ax1(2)]
 @test A.data[1:2,:,:,:] == A[Axis{:d1}(Interval(.1,.2))]       == A[Interval(.1,.2),:,:,:]       == A[Interval(.1,.2),:,:,:,1]       == A[Interval(.1,.2)]
 @test A.data[:,1:2,:,:] == A[Axis{:d2}(Interval(1//10,2//10))] == A[:,Interval(1//10,2//10),:,:] == A[:,Interval(1//10,2//10),:,:,1] == A[:,Interval(1//10,2//10)]
 @test A.data[:,:,1:2,:] == A[Axis{:d3}(["1","2"])]             == A[:,:,["1","2"],:]             == A[:,:,["1","2"],:,1]             == A[:,:,["1","2"]]


### PR DESCRIPTION
If `ax` is an `Axis{name,T}`, then `ax(2)` constructs `Axis{name,Int}(2)` which can be handy for slicing. Ref #33.